### PR TITLE
Add a basic settings page

### DIFF
--- a/Social Contributor.xcodeproj/project.pbxproj
+++ b/Social Contributor.xcodeproj/project.pbxproj
@@ -13,6 +13,9 @@
 		E334B3792822D5BD002E9640 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E334B3782822D5BD002E9640 /* ContentView.swift */; };
 		E334B37B2822D5BE002E9640 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E334B37A2822D5BE002E9640 /* Assets.xcassets */; };
 		E334B37E2822D5BE002E9640 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = E334B37D2822D5BE002E9640 /* Preview Assets.xcassets */; };
+		FA0DC4312822F3D5009AC9CC /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0DC4302822F3D5009AC9CC /* SettingsView.swift */; };
+		FA0DC4332822F4E3009AC9CC /* SettingsLabelStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0DC4322822F4E3009AC9CC /* SettingsLabelStyle.swift */; };
+		FA0DC4362822F730009AC9CC /* String+BuildInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA0DC4352822F730009AC9CC /* String+BuildInfo.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -23,6 +26,9 @@
 		E334B3782822D5BD002E9640 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		E334B37A2822D5BE002E9640 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		E334B37D2822D5BE002E9640 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		FA0DC4302822F3D5009AC9CC /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		FA0DC4322822F4E3009AC9CC /* SettingsLabelStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLabelStyle.swift; sourceTree = "<group>"; };
+		FA0DC4352822F730009AC9CC /* String+BuildInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+BuildInfo.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -64,6 +70,8 @@
 		E334B3752822D5BD002E9640 /* Social Contributor */ = {
 			isa = PBXGroup;
 			children = (
+				FA0DC4342822F727009AC9CC /* Extension */,
+				FA0DC42F2822F3C7009AC9CC /* Screens */,
 				5C66C0962822ECDD00B66FF8 /* CoreData */,
 				E334B3762822D5BD002E9640 /* Social_ContributorApp.swift */,
 				E334B3782822D5BD002E9640 /* ContentView.swift */,
@@ -79,6 +87,23 @@
 				E334B37D2822D5BE002E9640 /* Preview Assets.xcassets */,
 			);
 			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+		FA0DC42F2822F3C7009AC9CC /* Screens */ = {
+			isa = PBXGroup;
+			children = (
+				FA0DC4302822F3D5009AC9CC /* SettingsView.swift */,
+				FA0DC4322822F4E3009AC9CC /* SettingsLabelStyle.swift */,
+			);
+			path = Screens;
+			sourceTree = "<group>";
+		};
+		FA0DC4342822F727009AC9CC /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				FA0DC4352822F730009AC9CC /* String+BuildInfo.swift */,
+			);
+			path = Extension;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -151,10 +176,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FA0DC4312822F3D5009AC9CC /* SettingsView.swift in Sources */,
+				FA0DC4362822F730009AC9CC /* String+BuildInfo.swift in Sources */,
 				E334B3792822D5BD002E9640 /* ContentView.swift in Sources */,
 				E334B3772822D5BD002E9640 /* Social_ContributorApp.swift in Sources */,
 				5C66C0932822ECCE00B66FF8 /* Model.xcdatamodeld in Sources */,
 				5C66C0952822ECDA00B66FF8 /* PersistenceController.swift in Sources */,
+				FA0DC4332822F4E3009AC9CC /* SettingsLabelStyle.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Social Contributor/ContentView.swift
+++ b/Social Contributor/ContentView.swift
@@ -16,7 +16,7 @@ struct ContentView: View {
                     Label("Home", systemImage: "house")
                 }
             
-            Text("Hello, Settings!")
+            SettingsView()
                 .tabItem {
                     Label("Settings", systemImage: "gearshape")
                 }

--- a/Social Contributor/Extension/String+BuildInfo.swift
+++ b/Social Contributor/Extension/String+BuildInfo.swift
@@ -1,0 +1,15 @@
+//
+//  String+BuildInfo.swift
+//  Social Contributor
+//
+//  Created by Alex Logan on 04/05/2022.
+//
+
+import Foundation
+
+extension String {
+    public static func basicBuildInfo() -> String {
+        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+        return version
+    }
+}

--- a/Social Contributor/Screens/SettingsLabelStyle.swift
+++ b/Social Contributor/Screens/SettingsLabelStyle.swift
@@ -1,0 +1,60 @@
+//
+//  SettingsLabelStyle.swift
+//  Social Contributor
+//
+//  Created by Alex Logan on 04/05/2022.
+//
+
+import Foundation
+import SwiftUI
+
+struct SettingsLabelStyle: LabelStyle {
+    // Base all sizing on the current accessibility scale so everyone can read it.
+    @ScaledMetric var accessibilityScale: CGFloat = 1
+
+    var cornerRadius: CGFloat {
+        6 * accessibilityScale
+    }
+    var iconFrameSize: CGFloat {
+        28 * accessibilityScale
+    }
+
+    let backgroundColor: Color
+
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .frame(width: iconFrameSize, height: iconFrameSize, alignment: .center)
+                .foregroundColor(backgroundColor)
+                .overlay(
+                    configuration.icon
+                        .font(font)
+                        .foregroundColor(.white)
+                )
+            configuration.title
+                .layoutPriority(1)
+                .font(font)
+                .foregroundColor(.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Spacer()
+        }
+    }
+
+    var font: Font {
+        .body.weight(.medium)
+    }
+}
+
+struct SettingsLabelStyle_Previews: PreviewProvider {
+    static var previews: some View {
+        List {
+            Label("Contribute", systemImage: "person.badge.plus")
+                .labelStyle(SettingsLabelStyle(backgroundColor: .orange))
+            Label("Help", systemImage: "questionmark.circle.fill")
+                .labelStyle(SettingsLabelStyle(backgroundColor: .blue))
+            Label("Contact", systemImage: "mail")
+                .labelStyle(SettingsLabelStyle(backgroundColor: .pink))
+        }
+    }
+}
+

--- a/Social Contributor/Screens/SettingsView.swift
+++ b/Social Contributor/Screens/SettingsView.swift
@@ -1,0 +1,52 @@
+//
+//  SettingsView.swift
+//  Social Contributor
+//
+//  Created by Alex Logan on 04/05/2022.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+    var body: some View {
+        NavigationView {
+            List {
+                aboutSection
+                contributionSection
+            }
+            .navigationTitle(Text("Settings"))
+        }
+    }
+    private var contributionSection: some View {
+        Section(content: {
+            Button(action: {
+                guard let githubUrl = URL(string: "https://github.com/adamrushy/social-swiftui-app") else {
+                    return
+                }
+                UIApplication.shared.open(githubUrl)
+            }, label: {
+                NavigationLink(destination: { EmptyView() }){
+                    Label("Github", systemImage: "chevron.left.forwardslash.chevron.right")
+                        .labelStyle(SettingsLabelStyle(backgroundColor: .black.opacity(0.7)))
+                }
+            })
+        }, header: {
+            Text("Contribution")
+        }, footer: {
+            Text("This app is an open source project started by @Adam9Rush, with contributions open.")
+        })
+    }
+
+    private var aboutSection: some View {
+        Section("About") {
+            Label("Version " + String.basicBuildInfo(), systemImage: "terminal.fill")
+                .labelStyle(SettingsLabelStyle(backgroundColor: .blue))
+        }
+    }
+}
+
+struct SettingsView_Previews: PreviewProvider {
+    static var previews: some View {
+        SettingsView()
+    }
+}


### PR DESCRIPTION
Follows on from the great starting work and adds a simple settings page with a lovely style for the labels. Limited to just a GitHub link and version number for now 😄 


| 🌞 | 🌚 | Accessibility |
| - | - | - | 
|![Simulator Screen Shot - iPhone 13 - 2022-05-04 at 19 14 25](https://user-images.githubusercontent.com/13989549/166799302-16f7273c-3a2e-4995-8ecc-26b8308521ff.png)|![Simulator Screen Shot - iPhone 13 - 2022-05-04 at 19 14 27](https://user-images.githubusercontent.com/13989549/166799337-56500dad-a8d5-464c-bafc-726d7a2f5209.png)|![Simulator Screen Shot - iPhone 13 - 2022-05-04 at 19 14 36](https://user-images.githubusercontent.com/13989549/166799365-e301f91c-50b7-4eea-a204-4cf702b572a8.png)| 

